### PR TITLE
Convert to a Moo class and allow the setting of the various port arguments.

### DIFF
--- a/lib/Test/Consul.pm
+++ b/lib/Test/Consul.pm
@@ -35,6 +35,8 @@ sub _unique_empty_port {
         $port = $current_port;
     }
 
+    # Make sure we return a scalar with just numeric data so it gets
+    # JSON encoded without quotes.
     return $port;
 }
 
@@ -155,12 +157,12 @@ sub start {
         bind_addr  => '127.0.0.1',
         ports => {
             dns      => -1,
-            http     => $self->port(),
+            http     => $self->port() + 0,
             https    => -1,
-            rpc      => $self->rpc_port(),
-            serf_lan => $self->serf_lan_port(),
-            serf_wan => $self->serf_wan_port(),
-            server   => $self->server_port(),
+            rpc      => $self->rpc_port() + 0,
+            serf_lan => $self->serf_lan_port() + 0,
+            serf_wan => $self->serf_wan_port() + 0,
+            server   => $self->server_port() + 0,
         },
     );
 

--- a/lib/Test/Consul.pm
+++ b/lib/Test/Consul.pm
@@ -2,8 +2,7 @@ package Test::Consul;
 
 # ABSTRACT: Run a consul server for testing
 
-use warnings;
-use strict;
+use namespace::autoclean;
 
 use File::Which qw(which);
 use JSON::MaybeXS qw(JSON encode_json);
@@ -13,17 +12,128 @@ use Carp qw(croak);
 use HTTP::Tiny;
 use Net::EmptyPort qw( check_port );
 use File::Temp qw( tempfile );
+use Scalar::Util qw( blessed );
 
-sub start {
-    my ($class, %args) = @_;
+use Moo;
+use Types::Standard qw( Bool Enum Undef );
+use Types::Common::Numeric qw( PositiveInt );
+use Types::Common::String qw( NonEmptySimpleStr );
 
-    my $bin = $args{bin} || $class->bin();
-    unless ($bin && -x $bin) {
-        croak "can't find consul binary";
+my $start_port = 49152;
+my $current_port = $start_port;
+my $end_port  = 65535;
+
+sub _unique_empty_port {
+    my ($udp_too) = @_;
+
+    my $port = 0;
+    while ($port == 0) {
+        $current_port ++;
+        $current_port = $start_port if $current_port > $end_port;
+        next if check_port( undef, $current_port, 'tcp' );
+        next if $udp_too and check_port( undef, $current_port, 'udp' );
+        $port = $current_port;
     }
 
-    my $port    = $args{port}    || _unique_empty_port();
-    my $datadir = $args{datadir};
+    return $port;
+}
+
+has _pid => (
+    is        => 'rw',
+    predicate => '_has_pid',
+    clearer   => '_clear_pid',
+);
+
+has port => (
+    is  => 'lazy',
+    isa => PositiveInt,
+);
+sub _build_port {
+    return _unique_empty_port();
+}
+
+has rpc_port => (
+    is  => 'lazy',
+    isa => PositiveInt,
+);
+sub _build_rpc_port {
+    return _unique_empty_port();
+}
+
+has serf_lan_port => ( 
+    is  => 'lazy',
+    isa => PositiveInt,
+);
+sub _build_serf_lan_port {
+    return _unique_empty_port( 1 );
+}
+
+has serf_wan_port => (
+    is  => 'lazy',
+    isa => PositiveInt,
+);
+sub _build_serf_wan_port {
+    return _unique_empty_port( 1 );
+}
+
+has server_port => (
+    is  => 'lazy',
+    isa => PositiveInt,
+);
+sub _build_server_port {
+    return _unique_empty_port();
+}
+
+has enable_acls => (
+    is  => 'ro',
+    isa => Bool,
+);
+
+has acl_default_policy => (
+    is      => 'ro',
+    isa     => Enum[qw( allow deny )],
+    default => 'allow',
+);
+
+has acl_master_token => (
+    is      => 'ro',
+    isa     => NonEmptySimpleStr,
+    default => '01234567-89AB-CDEF-GHIJ-KLMNOPQRSTUV',
+);
+
+has bin => (
+    is => 'lazy',
+    isa => NonEmptySimpleStr | Undef,
+);
+sub _build_bin {
+    my ($self) = @_;
+    return $self->found_bin();
+}
+
+has datadir => (
+    is        => 'ro',
+    isa       => NonEmptySimpleStr,
+    predicate => 1,
+);
+
+sub running {
+    my ($self) = @_;
+    return !!$self->_has_pid();
+}
+
+sub start {
+    my $self = shift;
+    my $is_class_method = 0;
+
+    if (!blessed $self) {
+      $self = $self->new( @_ );
+      $is_class_method = 1;
+    }
+
+    my $bin = $self->bin();
+    unless (defined($bin) && -x $bin) {
+        croak "can't find consul binary";
+    }
 
     # Make sure we have at least Consul 0.6.1 which supports the -dev option.
     my ($version) = qx{$bin version};
@@ -33,7 +143,6 @@ sub start {
     else {
         $version = 0;
     }
-
     unless ($version >= 6_001) {
         croak "consul not version 0.6.1 or newer";
     }
@@ -46,12 +155,12 @@ sub start {
         bind_addr  => '127.0.0.1',
         ports => {
             dns      => -1,
-            http     => $port,
+            http     => $self->port(),
             https    => -1,
-            rpc      => _unique_empty_port(),
-            serf_lan => _unique_empty_port(1),
-            serf_wan => _unique_empty_port(1),
-            server   => _unique_empty_port(),
+            rpc      => $self->rpc_port(),
+            serf_lan => $self->serf_lan_port(),
+            serf_wan => $self->serf_wan_port(),
+            server   => $self->server_port(),
         },
     );
 
@@ -62,22 +171,20 @@ sub start {
         $config{performance} = { raft_multiplier => 1 };
     }
 
-    my $enable_acls        = $args{enable_acls};
-    my $acl_default_policy = $args{acl_default_policy} || 'allow';
-    if ($enable_acls) {
-        $config{acl_master_token} = $class->acl_master_token();
-        $config{acl_default_policy} = $acl_default_policy;
+    if ($self->enable_acls()) {
+        $config{acl_master_token} = $self->acl_master_token();
+        $config{acl_default_policy} = $self->acl_default_policy();
         $config{acl_datacenter} = 'perl-test-consul';
-        $config{acl_token} = $class->acl_master_token();
+        $config{acl_token} = $self->acl_master_token();
     }
 
     my $configpath;
-    if (defined $datadir) {
-        $config{data_dir}  = $datadir;
-        $config{bootstrap} = JSON->true;
-        $config{server}    = JSON->true;
+    if ($self->has_datadir()) {
+        $config{data_dir}  = $self->datadir();
+        $config{bootstrap} = \1;
+        $config{server}    = \1;
 
-        my $datapath = path($datadir);
+        my $datapath = path($self->datadir());
         $datapath->remove_tree;
         $datapath->mkpath;
 
@@ -102,6 +209,7 @@ sub start {
     my $http = HTTP::Tiny->new(timeout => 10);
     my $now = time;
     my $res;
+    my $port = $self->port();
     while (time < $now+30) {
         $res = $http->get("http://127.0.0.1:$port/v1/status/leader");
         last if $res->{success} && $res->{content} =~ m/^"[0-9\.]+:[0-9]+"$/;
@@ -112,85 +220,55 @@ sub start {
         croak "consul API test failed: $res->{status} $res->{reason}";
     }
 
-    unlink $configpath if !defined $datadir;
+    unlink $configpath if !$self->has_datadir();
 
-    my $self = {
-        bin     => $bin,
-        port    => $port,
-        datadir => $datadir,
-        _pid    => $pid,
-        enable_acls        => $enable_acls,
-        acl_default_policy => $acl_default_policy,
-    };
+    $self->_pid( $pid );
 
-    return bless $self, $class;
+    return $self if $is_class_method;
+    return;
 }
 
-my $start_port = 49152;
-my $current_port = $start_port;
-my $end_port  = 65535;
-
-sub _unique_empty_port {
-    my ($udp_too) = @_;
-
-    my $port = 0;
-    while ($port == 0) {
-      $current_port ++;
-      $current_port = $start_port if $current_port > $end_port;
-      next if check_port( undef, $current_port, 'tcp' );
-      next if $udp_too and check_port( undef, $current_port, 'udp' );
-      $port = $current_port;
-    }
-
-    return $port;
-}
-
-sub skip_all_if_no_bin {
-  my ($self) = @_;
-
-  croak 'The skip_all_if_no_bin method may only be used if the plan ' .
-        'function is callable on the main package (which Test::More ' .
-        'and Test2::Tools::Basic provide)'
-        if !main->can('plan');
-
-  return if $self->bin();
-
-  main::plan( skip_all => 'The Consul binary must be available to run this test.' );
-}
-
-sub end {
+sub stop {
     my ($self) = @_;
-    return unless $self->{_pid};
-    my $pid = delete $self->{_pid};
+    return unless $self->_has_pid();
+    my $pid = $self->_pid();
+    $self->_clear_pid();
     kill 'TERM', $pid;
     my $now = time;
     while (time < $now+2) {
         return if waitpid($pid, WNOHANG) > 0;
     }
     kill 'KILL', $pid;
+    return;
+}
+
+sub end {
+    goto \&stop;
 }
 
 sub DESTROY {
-    goto \&end;
+    goto \&stop;
 }
 
-sub running { !!shift->{_pid} }
-
-sub port    { shift->{port} }
-sub datadir { shift->{datadir} }
-
-sub enable_acls        { shift->{enable_acls} }
-sub acl_default_policy { shift->{acl_default_policy} }
-sub acl_master_token   { '01234567-89AB-CDEF-GHIJ-KLMNOPQRSTUV' }
-
 my ($bin, $bin_searched_for);
-sub bin {
-  my ($self) = @_;
-  return $self->{bin} if ref $self;
-  return $bin if $bin_searched_for;
-  $bin = $ENV{CONSUL_BIN} || which "consul";
-  $bin_searched_for = 1;
-  return $bin;
+sub found_bin {
+    return $bin if $bin_searched_for;
+    $bin = $ENV{CONSUL_BIN} || which "consul";
+    $bin_searched_for = 1;
+    return $bin;
+}
+
+sub skip_all_if_no_bin {
+    my ($class) = @_;
+
+    croak 'The skip_all_if_no_bin method may only be used if the plan ' .
+          'function is callable on the main package (which Test::More ' .
+          'and Test2::Tools::Basic provide)'
+          if !main->can('plan');
+
+    return if defined $class->found_bin();
+
+    main::plan( skip_all => 'The Consul binary must be available to run this test.' );
 }
 
 1;
@@ -226,105 +304,105 @@ used to help test Consul-aware Perl programs.
 
 It's assumed that you have Consul 0.6.4 installed somewhere.
 
+=head1 ARGUMENTS
+
+=head2 port
+
+The TCP port for HTTP API endpoint.  Consul's default is C<8500>, but
+this defaults to a random unused port.
+
+=head2 rpc_port
+
+The TCP port for the RPC CLI endpoint.  Consul's default is C<8400>, but
+this defaults to a random unused port.
+
+=head2 serf_lan_port
+
+The TCP and UDP port for the Serf LAN.  Consul's default is C<8301>, but
+this defaults to a random unused port.
+
+=head2 serf_wan_port
+
+The TCP and UDP port for the Serf WAN.  Consul's default is C<8302>, but
+this defaults to a random unused port.
+
+=head2 server_port
+
+The TCP port for the RPC Server address.  Consul's default is C<8300>, but
+this defaults to a random unused port.
+
+=head2 enable_acls
+
+Set this to true to enable ACLs.
+
+=head2 acl_default_policy
+
+Set this to either C<allow> or C<deny>. The default is C<allow>.
+See L<https://www.consul.io/docs/agent/options.html#acl_default_policy> for more
+information.
+
+=head2 acl_master_token
+
+If L</enable_acls> is true then this token will be used as the master
+token.  By default this will be C<01234567-89AB-CDEF-GHIJ-KLMNOPQRSTUV>.
+
+=head2 bin
+
+Location of the C<consul> binary.  If not provided then the binary will
+be retrieved from L</found_bin>.
+
+=head2 datadir
+
+Directory for Consul's data store. If not provided, the C<-dev> option is used
+and no datadir is used.
+
+=head1 ATTRIBUTES
+
+=head2 running
+
+Returns C<true> if L</start> has been called and L</stop> has not been called.
+
 =head1 METHODS
 
 =head2 start
 
-    my $tc = Test::Consul->start;
+    # As an object method:
+    my $tc = Test::Consul->new( %args );
+    $tc->start();
+    
+    # As a class method:
+    my $tc = Test::Consul->start( %args );
 
 Starts a Consul instance. This method can take a moment to run, because it
 waits until Consul's HTTP endpoint is available before returning. If it fails
 for any reason an exception is thrown. In this way you can be sure that Consul
 is ready for service if this method returns successfully.
 
-The returned object is a guard. C<end> is called when it goes out of scope, so
-if you don't store it your Consul server will be killed before it even gets
-started.
+=head2 stop
 
-C<start> takes the following arguments:
-
-=over 4
-
-=item *
-
-C<port>
-
-Port for the HTTP service. If not provided, an unused port between 49152 and 65535
-(inclusive) is chosen at random.
-
-=item *
-
-C<datadir>
-
-Directory for Consul's datastore. If not provided, the C<-dev> option is used and
-no datadir is used.
-
-=item *
-
-C<bin>
-
-Location of the C<consul> binary. If not provided, the C<CONSUL_BIN> env variable
-will be used, and if that is not set then C<$PATH> will be searched for it.
-
-=item *
-
-C<enable_acls>
-
-Set this to true to enable ACLs.
-
-=item *
-
-C<acl_default_policy>
-
-Set this to either C<allow> or C<deny>. The default is C<allow>.
-See L<https://www.consul.io/docs/agent/options.html#acl_default_policy> for more
-information.
-
-=back
-
-=head2 end
+    $tc->stop();
 
 Kill the Consul instance. Graceful shutdown is attempted first, and if it
 doesn't die within a couple of seconds, the process is killed.
 
-This method is also called if the guard object returned by C<start> falls out
-of scope.
+This method is also called if the instance of this class falls out of scope.
 
-=head2 running
+=head1 CLASS METHODS
 
-Returns a true value if the Consul instance is running, false otherwise.
+See also L</start> which acts as both a class and instance method.
 
-=head2 port
+=head2 found_bin
 
-Returns the port that the Consul's HTTP server is listening on.
-
-=head2 bin
-
-Returns the path to the C<consul> binary that was used to start the instance.
-
-=head2 datadir
-
-Returns the path to the data dir, if one was set.
-
-=head2 enable_acls
-
-Returns the C<enable_acls> argument which was set when L</start> was called.
-
-=head2 acl_default_policy
-
-Returns the C<acl_default_policy> argument which was set when L</start> was
-called.
-
-=head2 acl_master_token
-
-Returns the master ACL token.
+Return the value of the C<CONSUL_BIN> env var, if set, or uses L<File::Which>
+to search the system for an installed binary.  Returns C<undef> if no consul
+binary could be found.
 
 =head2 skip_all_if_no_bin
 
     Test::Consul->skip_all_if_no_bin;
 
 This class method issues a C<skip_all> on the main package if the
-consul binary could not be found.
+consul binary could not be found (L</found_bin> returns false).
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Initially I just wanted to be able to set the various port arguments (rpc_port, serf_wan_port, etc) and went ahead and adjusted this to be a Moo class for my own sanity.  Hope thats ok!  As much code and docs was saved as possible and `start()` still works as a class method, so this should be mostly, if not completely, be backwards compatible with the previously documented interface.