### PR TITLE
Disable gRPC TLS port on Consul >= 1.14.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+ - support for Consul >= 1.14.0 (disable gRPC TLS port)
 
 0.016     2020-03-11 22:30:45+11:00 Australia/Melbourne
  - add test-consul program

--- a/lib/Test/Consul.pm
+++ b/lib/Test/Consul.pm
@@ -198,6 +198,12 @@ sub start {
     $config{ports}{grpc} = -1;
   }
 
+  # Likewise for grpc above, 1.14.0 added grpc_tls which listens on 8503, and
+  # would clash with a second active Test::Consul
+  if ($self->version >= 1_014_000) {
+    $config{ports}{grpc_tls} = -1;
+  }
+
   if ($self->enable_acls()) {
     if ($self->version >= 1_004_000) {
     croak "ACLs not supported with Consul >= 1.4.0"


### PR DESCRIPTION
1.14.0 added gRPC TLS on port 8503 by default, meaning two Test::Consul instances couldn't run at the same time.