### PR TITLE
When picking unique ports ensure we can bind them

### DIFF
--- a/lib/Test/Consul.pm
+++ b/lib/Test/Consul.pm
@@ -33,7 +33,9 @@ sub _unique_empty_port {
     $current_port ++;
     $current_port = $start_port if $current_port > $end_port;
     next if check_port($current_port, 'tcp');
+    next if ! can_bind('127.0.0.1', $current_port, 'tcp');
     next if $udp_too and check_port($current_port, 'udp');
+    next if $udp_too and (! can_bind('127.0.0.1', $current_port, 'udp'));
     $port = $current_port;
   }
 


### PR DESCRIPTION
A client socket could be using the port since we're pulling from the default linux ephemeral port range. check_port() only makes sure a server isn't already running there by using connect(), which isn't sufficient to make sure *we* can bind it.